### PR TITLE
feat: add season history with selector on classement and matchs pages

### DIFF
--- a/app/(app)/classement/page.tsx
+++ b/app/(app)/classement/page.tsx
@@ -1,26 +1,34 @@
 "use client";
 
 import BoxModule from "@/components/layout/boxModule";
-import { Button } from "@/components/ui/button";
 import { getTeamLogo } from "@/lib/getTeamLogo";
 import { getTeamName } from "@/lib/getTeamName";
 import { cn } from "@/lib/utils";
 import { useRankingStore } from "@/store/useRankingStore";
-import { ChevronDown, ChevronUp, ExternalLink } from "lucide-react";
+import { useSeasonStore } from "@/store/useSeasonStore";
+import SeasonSelector from "@/components/season-selector";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import Image from "next/image";
-import Link from "next/link";
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
 import MetadataHead from "@/components/metadata-head";
 import { classementMetadata } from "./metadata";
 
 export default function Equipe() {
   const { rankings, isLoading, fetchRankings } = useRankingStore();
-
-  console.log(rankings);
+  const { setSelectedSeason } = useSeasonStore();
+  const isArchived = useSeasonStore((s) => s.isArchivedSeason());
 
   useEffect(() => {
+    setSelectedSeason(null);
     fetchRankings();
-  }, [fetchRankings]);
+  }, [fetchRankings, setSelectedSeason]);
+
+  const handleSeasonChange = useCallback(
+    (seasonId: number | null) => {
+      fetchRankings(seasonId);
+    },
+    [fetchRankings],
+  );
 
   const statsForTeams = [
     "played",
@@ -37,6 +45,7 @@ export default function Equipe() {
       <div className="my-30 container mx-auto flex flex-col gap-8 md:px-0 px-6">
         <div className="w-full flex justify-between items-center">
           <h1 className="text-4xl font-marjorie italic font-bold">Classement</h1>
+          <SeasonSelector onSeasonChange={handleSeasonChange} />
         </div>
         <BoxModule className="flex flex-col h-full">
           <div className="flex justify-between items-center w-full font-bold uppercase text-spanish-bg-lighter p-2">
@@ -68,11 +77,7 @@ export default function Equipe() {
       <div className="my-30 container mx-auto flex flex-col gap-8 md:px-0 px-6">
       <div className="w-full flex justify-between items-center">
         <h1 className="text-4xl font-marjorie italic font-bold">Classement</h1>
-        <Link href="https://www.lffs.eu" target="_blank">
-          <Button className="font-nugros">
-            LFFS P4G <ExternalLink />
-          </Button>
-        </Link>
+        <SeasonSelector onSeasonChange={handleSeasonChange} />
       </div>
       <BoxModule className="flex flex-col h-full">
         <div className="flex justify-between items-center w-full font-bold uppercase text-spanish-bg-lighter">
@@ -111,9 +116,10 @@ export default function Equipe() {
             >
               <div className="flex gap-4 items-center">
                 <p className="w-4 h-4 flex items-center justify-center">
-                  {team.positionChange === "no_change" ||
+                  {isArchived ? (
+                    "-"
+                  ) : team.positionChange === "no_change" ||
                   team.positionChange === null ? (
-                    // <Equal className="text-white" />
                     "-"
                   ) : team.positionChange === "up" ? (
                     <ChevronUp className="text-green-500" />

--- a/app/(app)/matchs/page.tsx
+++ b/app/(app)/matchs/page.tsx
@@ -10,6 +10,8 @@ import { getTeamName } from "@/lib/getTeamName";
 import { getVenueById } from "@/lib/getVenueById";
 import { cn } from "@/lib/utils";
 import { useMatchsStore } from "@/store/useMatchsStore";
+import { useSeasonStore } from "@/store/useSeasonStore";
+import SeasonSelector from "@/components/season-selector";
 import {
   ExternalLink,
   Handshake,
@@ -19,7 +21,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { toast } from "sonner";
 import { matchsMetadata } from "./metadata";
 
@@ -27,10 +29,20 @@ export default function Matchs() {
   const { isMobile } = useBreakpoint();
   const { matchs, isLoading, fetchMatchs } = useMatchsStore();
   const { breakpoint } = useBreakpoint();
+  const { setSelectedSeason } = useSeasonStore();
+  const isArchived = useSeasonStore((s) => s.isArchivedSeason());
 
   useEffect(() => {
+    setSelectedSeason(null);
     fetchMatchs();
-  }, [fetchMatchs]);
+  }, [fetchMatchs, setSelectedSeason]);
+
+  const handleSeasonChange = useCallback(
+    (seasonId: number | null) => {
+      fetchMatchs(seasonId);
+    },
+    [fetchMatchs],
+  );
 
   const now = new Date();
 
@@ -62,18 +74,21 @@ export default function Matchs() {
   const matchRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   useEffect(() => {
-    if (fallbackIndex !== -1 && matchRefs.current[fallbackIndex]) {
+    if (!isArchived && fallbackIndex !== -1 && matchRefs.current[fallbackIndex]) {
       matchRefs.current[fallbackIndex]?.scrollIntoView({
         behavior: "instant",
         block: isMobile ? "end" : "center",
       });
     }
-  }, [fallbackIndex, isMobile]);
+  }, [fallbackIndex, isMobile, isArchived]);
 
   if (isLoading) {
     return (
       <div className="my-30 container mx-auto flex flex-col gap-8 lg:px-0 px-6">
-        <h1 className="text-4xl font-marjorie italic font-bold">Nos matchs</h1>
+        <div className="w-full flex justify-between items-center">
+          <h1 className="text-4xl font-marjorie italic font-bold">Nos matchs</h1>
+          <SeasonSelector onSeasonChange={handleSeasonChange} />
+        </div>
         <div className="flex flex-col gap-4">
           {Array.from({ length: 6 }).map((_, i) => (
             <BoxModule key={i} className="flex flex-col gap-4 p-4 animate-pulse">
@@ -107,7 +122,10 @@ export default function Matchs() {
     <>
       <MetadataHead metadata={matchsMetadata} />
       <div className="my-30 container mx-auto flex flex-col gap-8 lg:px-0 px-6">
-        <h1 className="text-4xl font-marjorie italic font-bold">Nos matchs</h1>
+        <div className="w-full flex justify-between items-center">
+          <h1 className="text-4xl font-marjorie italic font-bold">Nos matchs</h1>
+          <SeasonSelector onSeasonChange={handleSeasonChange} />
+        </div>
         {validMatchs.map((match, index) => {
           const today = new Date();
           const matchDateTime = new Date(`${match.date}T${match.time}`);

--- a/app/api/public/matches/[seasonId]/route.ts
+++ b/app/api/public/matches/[seasonId]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server'
+import { unstable_cache } from 'next/cache'
+import { getPayloadClient } from '@/lib/payload'
+
+async function getMatchesBySeason(seasonId: number) {
+  const payload = await getPayloadClient()
+
+  const result = await payload.find({
+    collection: 'matches',
+    limit: 1000,
+    sort: 'date',
+    where: { season: { equals: seasonId } },
+  })
+
+  return result.docs.map((m) => ({
+    id: m.id,
+    home_team: m.home_team,
+    away_team: m.away_team,
+    score_home: m.score_home,
+    score_away: m.score_away,
+    date: m.date ? m.date.split('T')[0] : null,
+    time: m.time,
+    venue_id: m.venue_id,
+    venue_name: m.venue_name,
+    serie_reference: m.serie_reference,
+    live_link: m.live_link,
+    replay_link: m.replay_link,
+  }))
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ seasonId: string }> },
+) {
+  try {
+    const { seasonId } = await params
+    const id = Number(seasonId)
+    if (isNaN(id)) {
+      return NextResponse.json({ error: 'Invalid season ID' }, { status: 400 })
+    }
+
+    const getCached = unstable_cache(
+      () => getMatchesBySeason(id),
+      ['matches', seasonId],
+      { tags: ['matches'] },
+    )
+    const data = await getCached()
+
+    return NextResponse.json({ data })
+  } catch (error) {
+    console.error('Error fetching matches by season:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/public/rankings/[seasonId]/route.ts
+++ b/app/api/public/rankings/[seasonId]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server'
+import { unstable_cache } from 'next/cache'
+import { getPayloadClient } from '@/lib/payload'
+
+async function getRankingsBySeason(seasonId: number) {
+  const payload = await getPayloadClient()
+
+  const result = await payload.find({
+    collection: 'rankings',
+    limit: 1000,
+    sort: 'position',
+    where: { season: { equals: seasonId } },
+  })
+
+  return result.docs.map((r) => ({
+    id: r.id,
+    team_name: r.team_name,
+    position: r.position,
+    played: r.played,
+    points: r.points,
+    wins: r.wins,
+    draws: r.draws,
+    losses: r.losses,
+    goals_for: r.goals_for,
+    goals_against: r.goals_against,
+    goal_difference: r.goal_difference,
+    result_sequence: r.result_sequence,
+    positionChange: r.positionChange,
+  }))
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ seasonId: string }> },
+) {
+  try {
+    const { seasonId } = await params
+    const id = Number(seasonId)
+    if (isNaN(id)) {
+      return NextResponse.json({ error: 'Invalid season ID' }, { status: 400 })
+    }
+
+    const getCached = unstable_cache(
+      () => getRankingsBySeason(id),
+      ['rankings', seasonId],
+      { tags: ['rankings'] },
+    )
+    const data = await getCached()
+
+    return NextResponse.json({ data })
+  } catch (error) {
+    console.error('Error fetching rankings by season:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/public/seasons/route.ts
+++ b/app/api/public/seasons/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server'
+import { unstable_cache } from 'next/cache'
+import { getPayloadClient } from '@/lib/payload'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+async function getSeasons() {
+  const payload = await getPayloadClient()
+
+  const result = await payload.find({
+    collection: 'seasons',
+    where: {
+      or: [
+        { active: { equals: true } },
+        { archived: { equals: true } },
+      ],
+    },
+    sort: '-start_date',
+    limit: 100,
+  })
+
+  return result.docs.map((s) => {
+    // Build label like "P4G (25-26)" from serie_name + name
+    const shortName = s.name
+      ? s.name.replace(/^20(\d{2})-20(\d{2})$/, '$1-$2')
+      : s.name
+    const label = s.serie_name
+      ? `${s.serie_name} (${shortName})`
+      : shortName || s.name
+
+    return {
+      id: s.id,
+      name: s.name,
+      label,
+      active: s.active,
+      archived: s.archived,
+    }
+  })
+}
+
+const getCachedSeasons = unstable_cache(getSeasons, ['seasons'], {
+  tags: ['seasons'],
+})
+
+export async function GET() {
+  try {
+    const data = await getCachedSeasons()
+    return NextResponse.json({ data })
+  } catch (error) {
+    console.error('Error fetching seasons:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/components/season-selector.tsx
+++ b/src/components/season-selector.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSeasonStore } from "@/store/useSeasonStore";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type SeasonSelectorProps = {
+  onSeasonChange: (seasonId: number | null) => void;
+};
+
+export default function SeasonSelector({ onSeasonChange }: SeasonSelectorProps) {
+  const { seasons, fetchSeasons, selectedSeasonId, setSelectedSeason } =
+    useSeasonStore();
+
+  useEffect(() => {
+    if (seasons.length === 0) {
+      fetchSeasons();
+    }
+  }, [seasons.length, fetchSeasons]);
+
+  if (seasons.length <= 1) return null;
+
+  const activeSeason = seasons.find((s) => s.active);
+  const currentValue = selectedSeasonId
+    ? String(selectedSeasonId)
+    : activeSeason
+      ? String(activeSeason.id)
+      : undefined;
+
+  const handleChange = (value: string) => {
+    const id = Number(value);
+    const isActive = seasons.find((s) => s.id === id)?.active;
+    const seasonId = isActive ? null : id;
+    setSelectedSeason(seasonId);
+    onSeasonChange(seasonId);
+  };
+
+  return (
+    <Select value={currentValue} onValueChange={handleChange}>
+      <SelectTrigger size="sm">
+        <SelectValue placeholder="Saison" />
+      </SelectTrigger>
+      <SelectContent>
+        {seasons.map((season) => (
+          <SelectItem key={season.id} value={String(season.id)}>
+            {season.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/payload/collections/Seasons.ts
+++ b/src/payload/collections/Seasons.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from 'payload'
 import { isAdmin } from '../access'
+import { revalidateAfterChange, revalidateAfterDelete } from '../hooks/revalidateCache'
 
 export const Seasons: CollectionConfig = {
   slug: 'seasons',
@@ -18,16 +19,19 @@ export const Seasons: CollectionConfig = {
     beforeChange: [
       async ({ data, req }) => {
         // Deactivate all other seasons when one is set to active
+        // and auto-archive the previously active season
         if (data?.active) {
           await req.payload.update({
             collection: 'seasons',
             where: { active: { equals: true } },
-            data: { active: false },
+            data: { active: false, archived: true },
           })
         }
         return data
       },
     ],
+    afterChange: [revalidateAfterChange(['seasons', 'rankings', 'matches'])],
+    afterDelete: [revalidateAfterDelete(['seasons'])],
   },
   fields: [
     {
@@ -47,6 +51,11 @@ export const Seasons: CollectionConfig = {
       type: 'text',
       required: true,
       label: 'LFFS Serie ID',
+    },
+    {
+      name: 'serie_name',
+      type: 'text',
+      label: 'Nom de la serie (ex: P4G)',
     },
     {
       name: 'active',

--- a/src/store/useMatchsStore.ts
+++ b/src/store/useMatchsStore.ts
@@ -18,7 +18,7 @@ type Match = {
 type State = {
   matchs: Match[];
   isLoading: boolean;
-  fetchMatchs: () => Promise<void>;
+  fetchMatchs: (seasonId?: number | null) => Promise<void>;
 };
 
 type MatchAPIResponse = {
@@ -41,13 +41,14 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_STRAP
 export const useMatchsStore = create<State>((set) => ({
   matchs: [],
   isLoading: false,
-  fetchMatchs: async () => {
+  fetchMatchs: async (seasonId) => {
     set({ isLoading: true, matchs: [] });
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/public/matches`
-      );
+      const url = seasonId
+        ? `${API_URL}/api/public/matches/${seasonId}`
+        : `${API_URL}/api/public/matches`;
+      const res = await fetch(url);
       const json = await res.json();
 
       set({

--- a/src/store/useRankingStore.ts
+++ b/src/store/useRankingStore.ts
@@ -19,7 +19,7 @@ type Ranking = {
 type State = {
   rankings: Ranking[];
   isLoading: boolean;
-  fetchRankings: () => Promise<void>;
+  fetchRankings: (seasonId?: number | null) => Promise<void>;
 };
 
 type RankingAPIResponse = {
@@ -43,13 +43,14 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_STRAP
 export const useRankingStore = create<State>((set) => ({
   rankings: [],
   isLoading: false,
-  fetchRankings: async () => {
+  fetchRankings: async (seasonId) => {
     set({ isLoading: true, rankings: [] });
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/public/rankings`
-      );
+      const url = seasonId
+        ? `${API_URL}/api/public/rankings/${seasonId}`
+        : `${API_URL}/api/public/rankings`;
+      const res = await fetch(url);
       const json = await res.json();
 
       set({

--- a/src/store/useSeasonStore.ts
+++ b/src/store/useSeasonStore.ts
@@ -1,0 +1,48 @@
+import { create } from "zustand";
+
+type Season = {
+  id: number;
+  name: string;
+  label: string;
+  active: boolean;
+  archived: boolean;
+};
+
+type State = {
+  seasons: Season[];
+  selectedSeasonId: number | null;
+  isLoading: boolean;
+  fetchSeasons: () => Promise<void>;
+  setSelectedSeason: (id: number | null) => void;
+  isArchivedSeason: () => boolean;
+};
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_STRAPI_API_URL || "";
+
+export const useSeasonStore = create<State>((set, get) => ({
+  seasons: [],
+  selectedSeasonId: null,
+  isLoading: false,
+  fetchSeasons: async () => {
+    set({ isLoading: true });
+    try {
+      const res = await fetch(`${API_URL}/api/public/seasons`);
+      const json = await res.json();
+      const seasons = (json.data || []) as Season[];
+      set({ seasons });
+    } catch (error) {
+      console.error("Failed to fetch seasons:", error);
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+  setSelectedSeason: (id) => {
+    set({ selectedSeasonId: id });
+  },
+  isArchivedSeason: () => {
+    const { selectedSeasonId, seasons } = get();
+    if (!selectedSeasonId) return false;
+    const season = seasons.find((s) => s.id === selectedSeasonId);
+    return season ? !season.active : false;
+  },
+}));


### PR DESCRIPTION
Browse archived seasons via a dropdown on rankings and matchs pages. Data model already linked rankings/matches to seasons — this adds:
- API routes for listing seasons and fetching data by season ID
- Season selector component (hidden when only one season exists)
- Auto-reset to active season on page navigation
- Auto-archive previous season when a new one is activated
- serie_name field on Seasons for display labels (e.g. "P4G (25-26)")